### PR TITLE
notify-release workflow updated

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -2,6 +2,8 @@ name: Notify release
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   schedule:
     - cron: '30 8 * * *'
 


### PR DESCRIPTION
This PR updates the notify-release workflow to automatically close the issue(pending release) as soon as a new release is published

closes #147 